### PR TITLE
Refactor hashed_fold_scaffold and sha256 in random_split.py and scaffold_network.py

### DIFF
--- a/chemfold/random_split.py
+++ b/chemfold/random_split.py
@@ -29,11 +29,22 @@ logger.addHandler(shandler)
 
 def hashed_fold_scaffold(scaff, secret, nfolds = 5):
     scaff = str(scaff).encode("ASCII")
-    #h = sha256([scaff], secret)
-    m = hmac.new(secret, b'', hashlib.sha256)
-    m.update(scaff)
-    random.seed(m.digest(), version=2)
+    h = sha256([scaff], secret)
+    random.seed(h, version=2)
     return random.randint(0, nfolds - 1)
+
+def sha256(inputs, secret):
+    """
+    Encryption function using python's pre-installed packages HMAC and hashlib.
+    We are using SHA256 (it is equal in security to SHA512).
+    :param inputs: input strings
+    :param secret: given pharma partner key
+    :return:
+    """
+    m = hmac.new(secret, b'', hashlib.sha256)
+    for i in inputs:
+        m.update(i)
+    return m.digest()
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='compute fold vectors based on Scaffolds')

--- a/chemfold/scaffold_network.py
+++ b/chemfold/scaffold_network.py
@@ -32,9 +32,7 @@ def murcko_scaff_smiles(mol_smiles):
 def hashed_fold_scaffold(scaff, secret, nfolds = 5):
     scaff = str(scaff).encode("ASCII")
     h = sha256([scaff], secret)
-    m = hmac.new(secret, b'', hashlib.sha256)
-    m.update(scaff)
-    random.seed(m.digest(), version=2)
+    random.seed(h, version=2)
     return random.randint(0, nfolds - 1)
 
 def sha256(inputs, secret):


### PR DESCRIPTION
Hi there,

I've made some changes to the `random_split.py` and `scaffold_network.py` files, specifically in the `hashed_fold_scaffold` and `sha256` functions. Here are the main modifications:

- Removed commented-out code.
- Enhanced the `hashed_fold_scaffold` function by utilizing the `sha256` function and improved the seeding logic.

These changes are aimed at streamlining the code and ensuring that the encryption is applied uniformly.
Please review the changes and let me know if any adjustments are required.

Thank you.